### PR TITLE
fix(frontend): show placeholder image for product

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Show placeholder image for products with no image provided

Issue Link: [#INC-532](https://github.com/ObelusFamily/Anythink-Market-kpt8g/issues/2)

![image](https://user-images.githubusercontent.com/62152476/189426902-c03335e4-b873-4383-bf64-9113155ab35d.png)


